### PR TITLE
added helpers.js

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,17 @@
+require("./jsdoc.def.js")
+const Sequelize = require("sequelize")
+
+/**
+ * This function will monkey-patch a Sequelize Model injecting the graphql property 
+ * for sequelize-graphql-schema library
+ * @instance
+ * @param {Sequelize.Model} model - The sequelize model to monkey patch.
+ * @param {SeqGraphQL} opt - object with all information needed for sequelize-graphql-schema and our node-platform lib.
+ */
+function define(model, opt = defOpt) {
+    model.graphql = opt.graphql;
+}
+
+module.exports = {
+    define
+}


### PR DESCRIPTION
This file includes (for now) a function called "define" that thankfully to JSDoc is able to give the developer an auto-completion help using jsdoc.def.js documentation.

So you can import this file in your sequelize model to monkey patch the model object with .graphql property and auto-completion.
